### PR TITLE
bugfix: When creating directories or uploading files in a non-root directory, there was an issue of incorrect generated locations.

### DIFF
--- a/webdav.js
+++ b/webdav.js
@@ -167,7 +167,8 @@ const WebDAVNavigator = (url, options) => {
 		(async () => {
 			for (var i = 0; i < files.length; i++) {
 				var f = files[i];
-				await reqOrError('PUT', current_url + encodeURIComponent(f.name), f);
+				var parent_url = current_url.endsWith('/') ? current_url : current_url + '/';
+				await reqOrError('PUT', parent_url + encodeURIComponent(f.name), f);
 			}
 
 			window.setTimeout(() => {
@@ -643,7 +644,8 @@ const WebDAVNavigator = (url, options) => {
 
 					name = encodeURIComponent(name);
 
-					req('MKCOL', current_url + '/' + name).then(() => openListing(current_url + '/' + name));
+					var parent_url = current_url.endsWith('/') ? current_url : current_url + '/';
+					req('MKCOL', parent_url + name).then(() => openListing(parent_url + name));
 					return false;
 				};
 			};

--- a/webdav.js
+++ b/webdav.js
@@ -643,7 +643,7 @@ const WebDAVNavigator = (url, options) => {
 
 					name = encodeURIComponent(name);
 
-					req('MKCOL', current_url + name).then(() => openListing(current_url + name + '/'));
+					req('MKCOL', current_url + '/' + name).then(() => openListing(current_url + '/' + name));
 					return false;
 				};
 			};


### PR DESCRIPTION
case 1：When creating a directory in a non-root directory, the resulting directory ends up being in the root directory.
case 2：When uploading files to a non-root directory, the uploaded files end up in the root directory, and the file names become the subdirectory name + the file name.